### PR TITLE
Prevent exception about missing master DB on CD servers & allow rule ordering

### DIFF
--- a/Hi.UrlRewrite/Entities/Rules/InboundRule.cs
+++ b/Hi.UrlRewrite/Entities/Rules/InboundRule.cs
@@ -26,6 +26,8 @@ namespace Hi.UrlRewrite.Entities.Rules
         public string Pattern { get; set; }
         public bool IgnoreCase { get; set; }
 
+        public int SortOrder { get; set; }
+
         //public IEnumerable<ServerVariable> ServerVariables { get; set; }
         //public IEnumerable<RequestHeader> RequestHeaders { get; set; }
         public IEnumerable<ResponseHeader> ResponseHeaders { get; set; }

--- a/Hi.UrlRewrite/Extensions/ItemExtensions.cs
+++ b/Hi.UrlRewrite/Extensions/ItemExtensions.cs
@@ -216,6 +216,7 @@ namespace Hi.UrlRewrite
             }
 
             inboundRule.SiteNameRestriction = siteNameRestriction;
+            inboundRule.SortOrder = inboundRuleItem.SortOrder;
 
             return inboundRule;
         }

--- a/Hi.UrlRewrite/Processing/InboundRuleInitializer.cs
+++ b/Hi.UrlRewrite/Processing/InboundRuleInitializer.cs
@@ -11,6 +11,8 @@ namespace Hi.UrlRewrite.Processing
 {
     public class InboundRuleInitializer
     {
+        private string masterDatabaseName = "master";
+
         public void Process(PipelineArgs args)
         {
             Log.Info(this, "Initializing URL Rewrite.");
@@ -40,7 +42,13 @@ namespace Hi.UrlRewrite.Processing
 
         private void DeployEventIfNecessary()
         {
-            var database = Sitecore.Data.Database.GetDatabase("master");
+            if (!Sitecore.Configuration.Factory.GetDatabaseNames().Contains(masterDatabaseName, StringComparer.InvariantCultureIgnoreCase))
+            {
+                Log.Info(this, "Skipping DeployEventIfNecessary() as '{0}' database not present", masterDatabaseName);
+                return;
+            }
+
+            var database = Sitecore.Data.Database.GetDatabase(masterDatabaseName);
             if (database == null)
             {
                 return;

--- a/Hi.UrlRewrite/Processing/RulesEngine.cs
+++ b/Hi.UrlRewrite/Processing/RulesEngine.cs
@@ -22,6 +22,15 @@ namespace Hi.UrlRewrite.Processing
 {
     public class RulesEngine
     {
+        private class InboundRuleComparer : IComparer<InboundRule>
+        {
+            public int Compare(InboundRule x, InboundRule y)
+            {
+                return x.SortOrder.CompareTo(y.SortOrder);
+            }
+
+            public static readonly InboundRuleComparer Instance = new InboundRuleComparer();
+        }
 
         private readonly Database db;
 
@@ -92,6 +101,17 @@ namespace Hi.UrlRewrite.Processing
                     }
                 }
             }
+
+            inboundRules.Sort(InboundRuleComparer.Instance);
+
+/// --
+            Log.Info(this, db, "-- Start - SORTED Inbound Rules --");
+            foreach (var v in inboundRules)
+            {
+                Log.Info(this, db, "{1}: {0}", v.Name, v.SortOrder);
+            }
+            Log.Info(this, db, "-- End - SORTED Inbound Rules --");
+/// --
 
             return inboundRules;
         }
@@ -309,6 +329,11 @@ namespace Hi.UrlRewrite.Processing
 
             if (baseRules != null)
             {
+                if (item.IsSimpleRedirectItem() || item.IsInboundRuleItem())
+                {
+                    (baseRules as List<InboundRule>).Sort(InboundRuleComparer.Instance);
+                }
+
                 var rules = baseRules.ToList();
 
                 action(item, redirectFolderItem, rules);

--- a/Hi.UrlRewrite/Processing/RulesEngine.cs
+++ b/Hi.UrlRewrite/Processing/RulesEngine.cs
@@ -104,15 +104,6 @@ namespace Hi.UrlRewrite.Processing
 
             inboundRules.Sort(InboundRuleComparer.Instance);
 
-/// --
-            Log.Info(this, db, "-- Start - SORTED Inbound Rules --");
-            foreach (var v in inboundRules)
-            {
-                Log.Info(this, db, "{1}: {0}", v.Name, v.SortOrder);
-            }
-            Log.Info(this, db, "-- End - SORTED Inbound Rules --");
-/// --
-
             return inboundRules;
         }
 

--- a/Hi.UrlRewrite/Templates/Inbound/InboundRuleItem.cs
+++ b/Hi.UrlRewrite/Templates/Inbound/InboundRuleItem.cs
@@ -7,6 +7,8 @@ namespace Hi.UrlRewrite.Templates.Inbound
     {
         public static readonly string TemplateId = "{69DCE9A6-D8C1-463D-AF95-B7FEB326013F}";
 
+        private int? _sortorder;
+
         #region Inherited Base Templates
 
         private readonly BaseRuleItem _BaseRuleItem;
@@ -38,6 +40,25 @@ namespace Hi.UrlRewrite.Templates.Inbound
                 return new LookupField(InnerItem.Fields["Action"]);
             }
         }
-            
+
+        public int SortOrder
+        {
+            get
+            {
+                if (!_sortorder.HasValue)
+                {
+                    int sortorder;
+                    if (!int.TryParse(base["__sortorder"], out sortorder))
+                    {
+                        sortorder = 0;
+                    }
+
+                    _sortorder = sortorder;
+                }
+
+                return _sortorder.Value;
+            }
+        }
+
     }
 }

--- a/Hi.UrlRewrite/Templates/Inbound/SimpleRedirectItem.cs
+++ b/Hi.UrlRewrite/Templates/Inbound/SimpleRedirectItem.cs
@@ -8,6 +8,8 @@ namespace Hi.UrlRewrite.Templates.Inbound
 
         public static readonly string TemplateId = "{E30B15B9-34CD-419C-8671-60FEAAAD5A46}";
 
+        private int? _sortorder;
+
         #region Inherited Base Templates
 
         private readonly BaseUrlRewriteItem _BaseUrlRewriteItem;
@@ -60,6 +62,24 @@ namespace Hi.UrlRewrite.Templates.Inbound
             }
         }
 
+        public int SortOrder
+        {
+            get
+            {
+                if (!_sortorder.HasValue)
+                {
+                    int sortorder;
+                    if (!int.TryParse(base["__sortorder"], out sortorder))
+                    {
+                        sortorder = 0;
+                    }
+
+                    _sortorder = sortorder;
+                }
+
+                return _sortorder.Value;
+            }
+        }
 
         #endregion //Field Instance Methods
     }


### PR DESCRIPTION
Having recently deployed the rewrite module into a production environment where the CD servers have no master database, my ops colleagues noted that the code logged an exception in this configuration:

    12816 10:58:04 ERROR UrlRewrite::Exception during initialization.
    Exception: System.InvalidOperationException
    Message: Could not find configuration node: databases/database[@id='master']
    Source: Sitecore.Kernel

This is down to `Sitecore.Data.Database.GetDatabase()` throwing rather than returning null in this scenario, I think.

In order to keep the people monitoring server logs happy, I've made a quick modification to the code so that it checks if the master database exists before trying to fetch it. Instead of logging an exception it now writes an info message to say that `InboundRuleInitializer.DeployEventIfNecessary()` didn't do anything due to the lack of master.

Hopefully that's a change that will help others too?

-- Edited to add --

Another thing I required for my deployment of the module was the ability to have rules processed in a defined order. I am dealing with a scenario where I have a set of specific rules, and a "catch all" rule to process any requests which did not trigger the specific ones.

The easiest way to implement rule priority like this seems to be making the rule processing obey the content item ordering in Sitecore, via the `__sortorder` field. It's not ideal (since rules in folders could have the same sort order here - which would need manual editing of the underlying field to resolve) but it covers my requirement without needing to add a new field to the rules for priority.

Adding this to the PR in case anyone else has a similar scenario.