### PR TITLE
Respect hierarchy when sorting

### DIFF
--- a/Hi.UrlRewrite/Caching/RulesCache.cs
+++ b/Hi.UrlRewrite/Caching/RulesCache.cs
@@ -1,15 +1,15 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using Hi.UrlRewrite.Entities.Rules;
 using Sitecore;
 using Sitecore.Caching;
 using Sitecore.Data;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Hi.UrlRewrite.Caching
 {
-    public class RulesCache : CustomCache
+	public class RulesCache : CustomCache
     {
         private Database _db;
         private const string inboundRulesKey = "InboundRules";
@@ -65,9 +65,16 @@ namespace Hi.UrlRewrite.Caching
             }
 
             SetObject(key, outboundRules, size);
-        }
+		}
 
+		public void ClearInboundRules()
+		{
+			RemoveKeysContaining(inboundRulesKey);
+		}
 
-
-    }
+		public void ClearOutboundRules()
+		{
+			RemoveKeysContaining(outboundRulesKey);
+		}
+	}
 }

--- a/Hi.UrlRewrite/Entities/Rules/InboundRule.cs
+++ b/Hi.UrlRewrite/Entities/Rules/InboundRule.cs
@@ -1,13 +1,13 @@
-﻿using Hi.UrlRewrite.Entities.Actions.Base;
+﻿using System;
+using System.Collections.Generic;
+using Hi.UrlRewrite.Entities.Actions.Base;
 using Hi.UrlRewrite.Entities.Conditions;
 using Hi.UrlRewrite.Entities.Match;
 using Hi.UrlRewrite.Entities.ServerVariables;
-using System;
-using System.Collections.Generic;
 
 namespace Hi.UrlRewrite.Entities.Rules
 {
-    [Serializable]
+	[Serializable]
     public class InboundRule : IBaseRule, IConditionList, /*IServerVariableList, IRequestHeaderList,*/ IResponseHeaderList
     {
         public Guid ItemId { get; set; }
@@ -40,7 +40,9 @@ namespace Hi.UrlRewrite.Entities.Rules
             ResponseHeaders = new List<ResponseHeader>();
         }
 
-
-
+	    public override string ToString()
+	    {
+		    return $"{Name} ({Pattern})";
+	    }
     }
 }

--- a/Hi.UrlRewrite/Extensions/ItemExtensions.cs
+++ b/Hi.UrlRewrite/Extensions/ItemExtensions.cs
@@ -1,4 +1,8 @@
-﻿using Hi.UrlRewrite.Entities.Actions;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using Hi.UrlRewrite.Entities.Actions;
 using Hi.UrlRewrite.Entities.Actions.Base;
 using Hi.UrlRewrite.Entities.Conditions;
 using Hi.UrlRewrite.Entities.Match;
@@ -17,14 +21,10 @@ using Hi.UrlRewrite.Templates.ServerVariables;
 using Sitecore;
 using Sitecore.Data;
 using Sitecore.Data.Items;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
 
 namespace Hi.UrlRewrite
 {
-    public static class ItemExtensions
+	public static class ItemExtensions
     {
 
         #region Conversions
@@ -885,12 +885,23 @@ namespace Hi.UrlRewrite
             return !IsTemplate(item) && item.TemplateID.ToString().Equals(InboundRuleItem.TemplateId, StringComparison.InvariantCultureIgnoreCase);
         }
 
-        public static bool IsInboundRuleItemChild(this Item item)
+	    public static bool IsInboundRuleItemChild(this Item item)
+	    {
+		    return IsInboundRuleItemChild(item, null);
+	    }
+
+	    public static bool IsInboundRuleItemChild(this Item item, ID parentId)
         {
-            if (item.Parent != null)
+	        Item itemParent = item.Parent;
+            if (item.Parent == null && parentId != (ID)null)
             {
-                return !IsTemplate(item) && item.Parent.TemplateID.ToString().Equals(InboundRuleItem.TemplateId, StringComparison.InvariantCultureIgnoreCase);
+	            itemParent = item.Database.GetItem(parentId);
             }
+
+	        if (itemParent != null)
+	        {
+				return !IsTemplate(item) && itemParent.TemplateID.ToString().Equals(InboundRuleItem.TemplateId, StringComparison.InvariantCultureIgnoreCase);
+			}
             return false;
         }
 

--- a/Hi.UrlRewrite/Templates/Inbound/InboundRuleItem.cs
+++ b/Hi.UrlRewrite/Templates/Inbound/InboundRuleItem.cs
@@ -3,12 +3,10 @@ using Sitecore.Data.Items;
 
 namespace Hi.UrlRewrite.Templates.Inbound
 {
-    public class InboundRuleItem : CustomItem
+	public class InboundRuleItem : CustomItem
     {
         public static readonly string TemplateId = "{69DCE9A6-D8C1-463D-AF95-B7FEB326013F}";
-
-        private int? _sortorder;
-
+		
         #region Inherited Base Templates
 
         private readonly BaseRuleItem _BaseRuleItem;
@@ -45,18 +43,7 @@ namespace Hi.UrlRewrite.Templates.Inbound
         {
             get
             {
-                if (!_sortorder.HasValue)
-                {
-                    int sortorder;
-                    if (!int.TryParse(base["__sortorder"], out sortorder))
-                    {
-                        sortorder = 0;
-                    }
-
-                    _sortorder = sortorder;
-                }
-
-                return _sortorder.Value;
+                return this.InnerItem.Appearance.Sortorder;
             }
         }
 

--- a/Hi.UrlRewrite/Templates/Inbound/SimpleRedirectItem.cs
+++ b/Hi.UrlRewrite/Templates/Inbound/SimpleRedirectItem.cs
@@ -3,13 +3,11 @@ using Sitecore.Data.Items;
 
 namespace Hi.UrlRewrite.Templates.Inbound
 {
-    public partial class SimpleRedirectItem : CustomItem
+	public partial class SimpleRedirectItem : CustomItem
     {
 
         public static readonly string TemplateId = "{E30B15B9-34CD-419C-8671-60FEAAAD5A46}";
-
-        private int? _sortorder;
-
+		
         #region Inherited Base Templates
 
         private readonly BaseUrlRewriteItem _BaseUrlRewriteItem;
@@ -66,18 +64,7 @@ namespace Hi.UrlRewrite.Templates.Inbound
         {
             get
             {
-                if (!_sortorder.HasValue)
-                {
-                    int sortorder;
-                    if (!int.TryParse(base["__sortorder"], out sortorder))
-                    {
-                        sortorder = 0;
-                    }
-
-                    _sortorder = sortorder;
-                }
-
-                return _sortorder.Value;
+                return this.InnerItem.Appearance.Sortorder;
             }
         }
 


### PR DESCRIPTION
This change causes the inbound rules and redirects to be processed in the order their appear in the tree, regardless of their hierarchy level. For example, given the below hierarchy:

- Redirect 1
- Redirect Subfolder 1
  - Redirect 1.1
  - Redirect 1.2
- Redirect 2
- Redirect 3
- Redirect Subfolder 2
  - Redirect 3.1
  - Redirect Subfolder 3.1
    - Redirect 3.1.1
    - Redirect 3.1.2
  - Redirect 3.2
- Redirect 4

The items will be processed in the following order:

- Redirect 1
- Redirect 1.1
- Redirect 1.2
- Redirect 2
- Redirect 3
- Redirect 3.1
- Redirect 3.1.1
- Redirect 3.1.2
- Redirect 3.2
- Redirect 4